### PR TITLE
set calendar start_date 0

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ copyright_holder = Ricardo SIGNES
 
 [Prereqs]
 autodie = 0
-Calendar::Simple = 0
+Calendar::Simple = 2 ; the default start_day has changed
 Color::Palette = 0.100000 ; hex colors that work
 Config::MVP = 2 ; new Reader API
 DateTime::Format::W3CDTF = 0

--- a/lib/WWW/AdventCalendar.pm
+++ b/lib/WWW/AdventCalendar.pm
@@ -6,7 +6,7 @@ use Moose;
 use MooseX::StrictConstructor;
 
 use autodie;
-use Calendar::Simple;
+use Calendar::Simple 2; # the default start_day has changed
 use Color::Palette 0.100002; # optimized_for, as_strict_css_hash
 use Color::Palette::Schema;
 use DateTime::Format::W3CDTF;
@@ -435,7 +435,7 @@ sub build {
       today  => $self->today,
       year   => $self->year,
       month  => \%month,
-      calendar => scalar calendar(12, $self->year),
+      calendar => scalar calendar(12, $self->year, 0),
       articles => $article,
     }),
   );


### PR DESCRIPTION
Fix #6 

https://metacpan.org/pod/Calendar::Simple#start_day says
> NOTE: As of version 2.0.0, the default start_day has changed. Previously, it was Sunday; now, it is Monday. This is so the default behaviour matches that of the standard Unix cal command.

So now, we need to set start_date `0` for Sunday.