### PR TITLE
New HTTPS option

### DIFF
--- a/bin/advcal
+++ b/bin/advcal
@@ -20,6 +20,7 @@ use Getopt::Long::Descriptive 0.083;
 
     -t --tracker      include Google Analytics; -t TRACKER-ID
     -y --year-links   place year links at the bottom of the page
+    -p --https        website is https
 
 For more detailed information, see L<WWW::AdventCalendar>.
 
@@ -32,10 +33,11 @@ my ($opt, $usage) = describe_options(
   [ 'share-dir=s',     'root of shared files', { default => './share'    } ],
   [ 'output-dir|o=s',  'output directory',     { default => './out'      } ],
   [ 'today=s',         'the day we treat as "today"; default to today'     ],
-  [],
+  [                                                                        ],
   [ 'tracker-id|t=s',  'include Google Analytics; -t TRACKER-ID'           ],
-  [ 'uri=s',           'base URI of the calendar, including trailing slash' ],
+  [ 'uri=s',           'base URI of the calendar, including trailing slash'],
   [ 'year-links|y',    'add year links to bottom of index.html'            ],
+  [ 'https|p',         'website is https (so gravatar is, etc...)'         ],
 );
 
 my $arg = {};

--- a/lib/WWW/AdventCalendar.pm
+++ b/lib/WWW/AdventCalendar.pm
@@ -98,6 +98,7 @@ Finally, running L<advcal> is easy, too.  Here is its usage:
 
     -t --tracker      include Google Analytics; -t TRACKER-ID
     -y --year-links   place year links at the bottom of the page
+    -p --https   website is https
 
 Options given on the command line override those loaded form configuration.  By
 running this program every day, we cause the calendar to be rebuilt, adding any
@@ -148,6 +149,7 @@ has article_dir => (is => 'rw', required => 1);
 has share_dir   => (is => 'rw', required => 1);
 has output_dir  => (is => 'rw', required => 1);
 has year_links  => (is => 'rw', required => 1, default => 0);
+has https  => (is => 'rw', required => 1, default => 0);
 
 has default_author => (
   is  => 'ro',
@@ -453,6 +455,7 @@ sub build {
       next    => ($i < $#dates ? $article->{ $dates[ $i + 1 ] } : undef),
       prev    => ($i > 0       ? $article->{ $dates[ $i - 1 ] } : undef),
       year    => $self->year,
+      https   => $self->https,
     });
 
     my $bytes = Encode::encode('utf-8', $txt);

--- a/share/templates/article.mhtml
+++ b/share/templates/article.mhtml
@@ -10,6 +10,7 @@ $article
 <%method content>
 <%args>
 $article
+$https
 $prev => undef
 $next => undef
 </%args>
@@ -19,7 +20,7 @@ $next => undef
 
 <% $article->body_html %>
 
-<& /credit.mhtml, article => $article &>
+<& /credit.mhtml, article => $article , https => $https &>
 
 <ul id="pager">
 % if ($prev) {

--- a/share/templates/credit.mhtml
+++ b/share/templates/credit.mhtml
@@ -1,10 +1,14 @@
-<%args>$article</%args>
+<%args>
+$article
+$https
+</%args>
 <div id='author'>
 <img alt='Gravatar Image' style='vertical-align:middle' src=<% Gravatar::URL::gravatar_url(
   email  => $article->author_email,
   rating => 'g',
   size   => 80,
   default => 'retro',
+  https => $https,
 ) %> />
 This article contributed by: <% $article->author |h %>
 </div>


### PR DESCRIPTION
Intended to fix https://github.com/perladvent/Perl-Advent/issues/261

HTTPS is not the default because I don't want to break other users that are possibly not https (e.g. I suspect [adventplanet](http://www.lenjaffe.com/AdventPlanet/) is using WWW::AdventCalendar)